### PR TITLE
moving args to the bottom so global qos can be applied also.

### DIFF
--- a/lib/AnyEvent/RabbitMQ/Channel.pm
+++ b/lib/AnyEvent/RabbitMQ/Channel.pm
@@ -669,9 +669,9 @@ sub qos {
         'Basic::Qos',
         {
             prefetch_count => 1,
-            %args,
             prefetch_size  => 0,
             global         => 0,
+            %args,
         },
         'Basic::QosOk',
         $cb,


### PR DESCRIPTION
You can call qos multiple times to set a per consumer limit and a global per channel limit.
See: https://www.rabbitmq.com/consumer-prefetch.html