### PR TITLE
set correct _state when connect unsuccesful

### DIFF
--- a/lib/AnyEvent/RabbitMQ.pm
+++ b/lib/AnyEvent/RabbitMQ.pm
@@ -139,9 +139,14 @@ sub connect {
             undef $conn;
             my $self = $weak_self or return;
 
-            my $fh = shift or return $args{on_failure}->(
-                sprintf('Error connecting to AMQP Server %s:%s: %s', $args{host}, $args{port}, $!)
-            );
+            my $fh = shift;
+
+            unless ($fh) {
+                $self->{_state} = _ST_CLOSED;
+                return $args{on_failure}->(
+                    sprintf('Error connecting to AMQP Server %s:%s: %s', $args{host}, $args{port}, $!)
+                );
+            }
 
             my $close_cb = $args{on_close};
             my $failure_cb = $args{on_failure};


### PR DESCRIPTION
There is exists bug, when you trying to connect to stopped instance or so.

for example:

```perl
    my $cb = AnyEvent->condvar;

    $self->mq()->connect(
        host  => 'db',
        port  => 5672,
        user  => 'guest',
        pass  => 'guest',
        vhost => '/',

        timeout    => 1,
        on_success => sub {
            $cb->send('success');
        },
        on_failure => sub {
            $cb->send('fail');
        },
        on_close => sub {
            warn "on_close";
        }
    );

   return $cb->recv();
```

if RabbitMQ server stopped on my local server "db" - everything is works, but I have notice at the end of my program:

    (in cleanup) open already in progress at /Users/dan/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/AnyEvent/RabbitMQ.pm line 630.

There problem is that after unsuccessful connection _state is still _ST_OPENING

I didn't dig so deep, but I Think there is few similar problems may exist.


Thanks.