### PR TITLE
old check was triggering only if on_return is provided

### DIFF
--- a/lib/AnyEvent/RabbitMQ/Channel.pm
+++ b/lib/AnyEvent/RabbitMQ/Channel.pm
@@ -430,9 +430,10 @@ sub publish {
 
     defined($header_args) or $header_args = {};
     defined($body) or $body = '';
-    defined($ack_cb) or defined($nack_cb) or defined($return_cb)
-       and !$self->{_is_confirm}
-       and croak "Can't set on_ack/on_nack/on_return callback when not in confirm mode";
+    if ( defined($ack_cb) or defined($nack_cb) or defined($return_cb) ) {
+        croak "Can't set on_ack/on_nack/on_return callback when not in confirm mode"
+            unless $self->{_is_confirm};
+    }
 
     my $tag;
     if ($self->{_is_confirm}) {


### PR DESCRIPTION
mixing '!/&&/||' and 'or/and/not' in one condition always bad
idea. Mixing 'and' with 'or' without parens even worse. Old
code was triggering error in one case as it works like this:

    unless ( $confirm ) {
        $ack or ( $nack or ( $return and $croak ) )
    }

So if we are not in confirm mode then croak if and only if return
callback is set, but not the others.

Use two conditions with nested block instead. I find it more readable
as well as correct.