### PR TITLE
fixes Makefile.PL for missing dot in INC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,5 @@
+BEGIN { unshift @INC, '.' }
+
 use inc::Module::Install;
 
 name 'AnyEvent-RabbitMQ';


### PR DESCRIPTION
dot was recently removed from @INC
need to add it in order to load
inc::Module::Install