### PR TITLE
Pass peername to AnyEvent::Handle so that TLS peer validation is possible

### DIFF
--- a/lib/AnyEvent/RabbitMQ.pm
+++ b/lib/AnyEvent/RabbitMQ.pm
@@ -170,6 +170,7 @@ sub connect {
                     $self->{drain_condvar}->send
                         if exists $self->{drain_condvar};
                 },
+                peername => $args{host},
                 $args{tls} ? (tls => 'connect') : (),
                 $args{tls_ctx} ? ( tls_ctx => $args{tls_ctx} ) : (),
             );


### PR DESCRIPTION
Hi @davel this is the commit alluded to in #22. This change provides the hostname to the TLS layer of the connection. Without it, the TLS layer is unable to validate the peer's hostname.